### PR TITLE
Migrate from `nvim-send` to `nvim --remote-expr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This plugin is [LSP](https://microsoft.github.io/language-server-protocol/)-inde
 
 ### Using **[vim-plug](https://github.com/junegunn/vim-plug#neovim):**
 ```viml
-Plug 'alopatindev/cargo-limit', { 'do': 'cargo install cargo-limit nvim-send' }
+Plug 'alopatindev/cargo-limit', { 'do': 'cargo install cargo-limit' }
 ```
 
 and run
@@ -109,9 +109,6 @@ nvim +PlugInstall +UpdateRemotePlugins +qa
 ```lua
 use {
   'alopatindev/cargo-limit',
-  config = function()
-    -- TODO
-  end,
 }
 ```
 
@@ -119,20 +116,17 @@ use {
 ```lua
 use {
   'alopatindev/cargo-limit',
-  -- TODO: dependence installation
 }
 ```
 
 ### Using [paq-nvim](https://github.com/savq/paq-nvim):
 ```lua
 paq {'alopatindev/cargo-limit'}
--- TODO: dependence installation
 ```
 
 ### Using [dein](https://github.com/Shougo/dein.vim):
 ```viml
 call dein#add('alopatindev/cargo-limit', { 'rev': 'master' })
-" TODO: dependence installation
 ```
 
 ### Optionally: F2 to save, F2 again to jump to next affected line

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ This tool is especially useful in combination with [cargo-watch](https://crates.
 <summary><b>💡 Neovim Plugin 👁️</b></summary>
 <p>
 
+Requires `nvim >= 0.7.0` and `git` to be installed.
+
 This plugin is [LSP](https://microsoft.github.io/language-server-protocol/)-independent, **it will keep working even when [rust-analyzer](https://rust-analyzer.github.io/) fails**.
 
 ### Using **[vim-plug](https://github.com/junegunn/vim-plug#neovim):**

--- a/README.md
+++ b/README.md
@@ -105,28 +105,44 @@ and run
 nvim +PlugInstall +UpdateRemotePlugins +qa
 ```
 
-### Using [lazy.nvim](https://github.com/folke/lazy.nvim):
+### Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
-use {
-  'alopatindev/cargo-limit',
-}
+{ 'alopatindev/cargo-limit', build = 'cargo install cargo-limit' },
+```
+
+and run
+```bash
+nvim --headless "+Lazy! sync" +qa
+```
+
+### [paq-nvim](https://github.com/savq/paq-nvim):
+```lua
+{ 'alopatindev/cargo-limit', build = ':!cargo install cargo-limit' },
+```
+
+and run
+```bash
+nvim +PaqSync +qa
 ```
 
 ### Using [packer.nvim](https://github.com/wbthomason/packer.nvim):
 ```lua
-use {
-  'alopatindev/cargo-limit',
-}
+{ use 'alopatindev/cargo-limit', run = ':!cargo install cargo-limit' }
 ```
 
-### Using [paq-nvim](https://github.com/savq/paq-nvim):
-```lua
-paq {'alopatindev/cargo-limit'}
+and run
+```bash
+nvim +PackerUpdate +qa
 ```
 
 ### Using [dein](https://github.com/Shougo/dein.vim):
 ```viml
-call dein#add('alopatindev/cargo-limit', { 'rev': 'master' })
+call dein#add('alopatindev/cargo-limit', { 'rev': 'master', 'hook_post_update': '!cargo install cargo-limit' })
+```
+
+and run
+```bash
+nvim --cmd '!call dein#install()'
 ```
 
 ### Optionally: F2 to save, F2 again to jump to next affected line
@@ -318,6 +334,10 @@ Your donations will help me allocate more time to resolve [issues](https://githu
 - **Ethereum** (ETH, DAI, etc.) `0xa879cdb1d7d859e6e425f8e50c4ee49f4b3a7b06`
 
 - **[Patreon](https://www.patreon.com/checkout/alopatindev/9785189)**
+
+- **[Liberapay](https://liberapay.com/alopatindev)**
+
+- **[Ko-fi](https://ko-fi.com/alopatindev)**
 
 ---
 

--- a/plugin/cargo-limit.vim
+++ b/plugin/cargo-limit.vim
@@ -194,6 +194,9 @@ if !exists('*CargoLimitOpen')
 endif
 
 if has('nvim')
+  if !has('nvim-0.7.0')
+    throw 'unsupported nvim version, expected >=0.7.0'
+  endif
   call jobstart(['cargo', 'metadata', '--quiet', '--format-version=1'], {
   \ 'on_stdout': function('s:on_cargo_metadata'),
   \ 'on_stderr': function('s:on_cargo_metadata'),

--- a/src/bin/_cargo-limit-open-in-nvim.rs
+++ b/src/bin/_cargo-limit-open-in-nvim.rs
@@ -15,7 +15,8 @@ impl NeovimCommand {
     fn from_editor_data<R: Read>(mut input: R) -> Result<Option<Self>> {
         let mut raw_editor_data = String::new();
         input.read_to_string(&mut raw_editor_data)?;
-        let command = format!(r#"<ESC>:call g:CargoLimitOpen({raw_editor_data})<Enter>"#);
+        let command =
+            format!("<Esc>:call g:CargoLimitOpen({raw_editor_data})<Enter><Esc>:echom ''<Enter>");
 
         let editor_data: EditorData = serde_json::from_str(&raw_editor_data)?;
         let escaped_workspace_root = editor_data.escaped_workspace_root();

--- a/src/bin/_cargo-limit-open-in-nvim.rs
+++ b/src/bin/_cargo-limit-open-in-nvim.rs
@@ -37,16 +37,18 @@ impl NeovimCommand {
             &self.command,
         ];
 
-        // FIXME: prints exit code on success?
         match Command::new("nvim").args(remote_send_args).output() {
             Ok(Output {
                 status,
                 stdout,
                 stderr,
             }) => {
-                let mut stdout_writer = io::stdout();
-                stdout_writer.write_all(&stdout)?;
-                stdout_writer.flush()?;
+                const EXPECTED_EXPR_RESULT: [u8; 1] = ['0' as u8];
+                if stdout != EXPECTED_EXPR_RESULT {
+                    let mut stdout_writer = io::stdout();
+                    stdout_writer.write_all(&stdout)?;
+                    stdout_writer.flush()?;
+                }
 
                 let failed_to_connect_is_the_only_error = stderr.starts_with(b"E247:")
                     && stderr.iter().filter(|i| **i == b'\n').count() == 1;

--- a/src/bin/_cargo-limit-open-in-nvim.rs
+++ b/src/bin/_cargo-limit-open-in-nvim.rs
@@ -43,7 +43,7 @@ impl NeovimCommand {
                 stdout,
                 stderr,
             }) => {
-                const EXPECTED_EXPR_RESULT: [u8; 1] = ['0' as u8];
+                const EXPECTED_EXPR_RESULT: [u8; 1] = [b'0'];
                 if stdout != EXPECTED_EXPR_RESULT {
                     let mut stdout_writer = io::stdout();
                     stdout_writer.write_all(&stdout)?;

--- a/src/options.rs
+++ b/src/options.rs
@@ -290,7 +290,7 @@ impl Options {
         if let Ok(new_value) = env::var(key) {
             *value = new_value
                 .parse()
-                .with_context(|| format!("invalid {} value", key))?;
+                .with_context(|| format!("invalid {key} value"))?;
         }
         Ok(())
     }
@@ -298,10 +298,9 @@ impl Options {
     fn validate_color(color: &str) -> Result<()> {
         if !VALID_COLORS.contains(&color) {
             return Err(format_err!(
-                "argument for {} must be {} (was {})",
+                "argument for {} must be {} (was {color})",
                 &COLOR[..COLOR.len() - 1],
                 VALID_COLORS.join(", "),
-                color,
             ));
         }
         Ok(())
@@ -310,10 +309,9 @@ impl Options {
     fn validate_message_format(format: &str) -> Result<()> {
         if !VALID_MESSAGE_FORMATS.contains(&format) {
             return Err(format_err!(
-                "argument for {} must be {} (was {})",
+                "argument for {} must be {} (was {format})",
                 &MESSAGE_FORMAT[..MESSAGE_FORMAT.len() - 1],
                 VALID_MESSAGE_FORMATS.join(", "),
-                format,
             ));
         }
         Ok(())
@@ -321,7 +319,7 @@ impl Options {
 
     fn add_color_arg(&mut self, value: &str) {
         self.args_after_app_args_delimiter
-            .push(format!("{}{}", COLOR, value));
+            .push(format!("{COLOR}{value}"));
     }
 }
 
@@ -347,8 +345,8 @@ impl ParsedSubcommand {
             if let Some(executable) = executable {
                 if executable == CARGO_EXECUTABLE
                     || executable == current_exe
-                    || executable == format!("l{}", subcommand)
-                    || executable == format!("ll{}", subcommand)
+                    || executable == format!("l{subcommand}")
+                    || executable == format!("ll{subcommand}")
                 {
                     let _ = peekable_args.next();
                 } else {

--- a/src/process.rs
+++ b/src/process.rs
@@ -116,7 +116,7 @@ impl CargoProcess {
                         .args(["/PID", pid.to_string().as_str(), "/t"])
                         .output()
                     {
-                        String::from_utf8_lossy(&stderr).starts_with("SUCCESS")
+                        stderr.starts_with(b"SUCCESS")
                     } else {
                         false
                     }

--- a/src/process.rs
+++ b/src/process.rs
@@ -164,5 +164,5 @@ impl StateExt for Arc<Atomic<State>> {
 }
 
 pub(crate) fn failed_to_execute_error_text<T: fmt::Debug>(app: T) -> String {
-    format!("failed to execute {:?}", app)
+    format!("failed to execute {app:?}")
 }


### PR DESCRIPTION
Closes #31

I also noticed that [nvim-send](https://github.com/alopatindev/nvim-send) no longer compiles on Windows for various reasons. If you still need it — you can install it with `cargo +1.63.0-x86_64-pc-windows-msvc install --locked nvim-send`.