### PR TITLE
Option to filter all messages (limit to 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This tool is especially useful in combination with [cargo-watch](https://crates.
 
 ### CARGO_MSG_LIMIT
 - limit compiler messages number
-- `0` means no limit, which is default
+- `0` means no limit, which is default, negative means 0
 
 ### CARGO_TIME_LIMIT
 - `cargo` execution time limit in seconds after encountering first compiling error

--- a/additional_environment_variables.txt
+++ b/additional_environment_variables.txt
@@ -1,5 +1,5 @@
 Additional environment variables:
-    CARGO_MSG_LIMIT     Limit compiler messages number (0 means no limit, which is default)
+    CARGO_MSG_LIMIT     Limit compiler messages number (0 means no limit, which is default, negative means 0)
     CARGO_TIME_LIMIT    Execution time limit in seconds after encountering first compiling error (0 means no limit, 1 is default)
     CARGO_ASC           Show compiler messages in ascending order (false is default)
     CARGO_FORCE_WARN    Show warnings even if errors still exist (false is default)

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -252,7 +252,7 @@ impl TransformedMessages {
             if no_limit {
                 Either::Left(messages)
             } else {
-                Either::Right(messages.take(limit_messages))
+                Either::Right(messages.take(limit_messages.max(0) as usize))
             }
         }
         .unzip();

--- a/src/options.rs
+++ b/src/options.rs
@@ -41,7 +41,8 @@ pub struct Options {
     terminal_supports_colors: bool,
 
     pub color: String,
-    pub limit_messages: usize,
+    /// Limit of messages to show. 0 means no limit, negative means limit to 0.
+    pub limit_messages: isize,
     pub time_limit_after_error: Option<Duration>,
     pub ascending_messages_order: bool,
     pub show_warnings_if_errors_exist: bool,


### PR DESCRIPTION
Extends `CARGO_MSG_LIMIT` to support negative values, where any negative value means 0 (show no messages).

Note that 0 itself cannot be used for this, as it is the default value and means "no limit".
Proposed syntax is not ideal, but it's backward compatible.

Usage:
```
CARGO_MSG_LIMIT=-1 cargo lrun ...
```

Use case: sometimes we just want to run a binary without showing any warnings, while:
- still showing errors
- avoiding a different build config (an alternative is `RUSTFLAGS=-Awarnings cargo run`, but it's a different build config and might cause a full rebuild)